### PR TITLE
Removed em-max

### DIFF
--- a/docs/components/Typography.md
+++ b/docs/components/Typography.md
@@ -53,8 +53,6 @@ It can be used with the following modifiers to achieve a variety of effects.
 
 <h1 class="em-high">High emphasis</h1>
 
-<h1 class="em-max">Maximum emphasis</h1>
-
 <h1 class="em-alt">Emphasis alternate</h1>
 ```
 


### PR DESCRIPTION
Removed the modifier class em-max from the docs because I want to discourage the font-weight of 700 being used.